### PR TITLE
Add directory to tmp to prevent exception in test

### DIFF
--- a/t/09-coverable-index.t
+++ b/t/09-coverable-index.t
@@ -55,7 +55,7 @@ my $index = CoverableIndexFile.new(:$lib);
 }
 
 {
-  lives-ok { CoverableIndexFile.new(:lib($*TMPDIR)) }, 'without index file'
+  lives-ok { CoverableIndexFile.new(:lib($*TMPDIR.add('test'))) }, 'without index file'
 }
 
 done-testing


### PR DESCRIPTION
In one class a directory is created in a given location parents. In one test this given location is $*TMPDIR pointing to /tmp on my system. Causes the test to fail because the parent directory '/' is readonly.

Fix this with just adding a directory in $*TMPDIR before calling the code. Another empty directory in $*TMPDIR should not be an issue.